### PR TITLE
polarization algorithms: usable for multigraphs

### DIFF
--- a/polarization_algorithms.py
+++ b/polarization_algorithms.py
@@ -114,7 +114,7 @@ def krackhardt_ratio_pol(G, ms):
     EL = 0
     IL = 0
     
-    for e in G.edges:
+    for e in G.edges():
         s, t = e
 
         if ms[s] != ms[t]:
@@ -137,7 +137,7 @@ def extended_krackhardt_ratio_pol(G, ms):
     c_b = len(G.subgraph(block_b).edges)
     c_ab = 0
     
-    for e in G.edges:
+    for e in G.edges():
         s, t = e
 
         if ms[s] != ms[t]:
@@ -204,7 +204,7 @@ def gmck_pol(G, ms):
 
     B = []
 
-    for e in G.edges:
+    for e in G.edges():
         s, t = e
 
         if ms[s] != ms[t]:


### PR DESCRIPTION
Before this commit, sometimes edges were accessed with `G.edges()` and sometimes they were accessed with `G.edges`. This commit replaces the later by the former.

The advantage of the former is that is also usable for multigraphs. When using graphs, both methods return a tuple `(s, t)`. But when using multigraphs, `G.edges` returns a tuple `(s, t, k)` with a key `k`, while `G.edges()` returns only a tuple `(s, t)`, as expected by the rest of the code.